### PR TITLE
Add fetch error handling

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,6 +4,7 @@ chrome.declarativeNetRequest.onRuleMatched.addListener((rule) => {
       .then(response => response.json())
       .then(data => {
         chrome.storage.local.set({ zeppelinData: data });
-      });
+      })
+      .catch(err => console.error('Fetch failed', err));
   }
 });


### PR DESCRIPTION
## Summary
- handle errors when fetching data by logging them in `background.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68614c97c2ac8331a403908cfe0ff597