### PR TITLE
Fix background listener and manifest

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,8 @@
-chrome.declarativeNetRequest.onRuleMatched.addListener((rule) => {
-  if (rule.rule.id === 1) {
-    fetch(rule.request.url)
-      .then(response => response.json())
-      .then(data => {
+chrome.declarativeNetRequest.onRuleMatchedDebug.addListener((info) => {
+  if (info.rule.ruleId === 1) {
+    fetch(info.request.url)
+      .then((response) => response.json())
+      .then((data) => {
         chrome.storage.local.set({ zeppelinData: data });
       });
   }

--- a/manifest.json
+++ b/manifest.json
@@ -5,12 +5,27 @@
   "description": "Captures data from Zeppelin API, sends to an external API for description, and allows editing and sending to a wiki.",
   "permissions": [
     "activeTab",
-    "scripting"
+    "scripting",
+    "storage",
+    "declarativeNetRequestWithHostAccess",
+    "declarativeNetRequestFeedback"
   ],
   "host_permissions": [
     "<all_urls>"
   ],
+  "background": {
+    "service_worker": "background.js"
+  },
   "action": {
     "default_popup": "popup.html"
+  },
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "rules",
+        "enabled": true,
+        "path": "rules.json"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add a background service worker to the manifest
- register rule listener with correct API
- configure declarative net request rules and required permissions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68614bd8b4c08331a69a3f6b08a25608