### PR TITLE
Implement hover button for table extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,11 @@ chrome.declarativeNetRequest.onRuleMatched.addListener((rule) => {
 
 Дополнительные настройки разрешений описаны в `rules.json`. Этот файл содержит правила для `declarativeNetRequest`, которые определяют, какие сетевые запросы будут перехватываться фоновым скриптом.
 
+### `content.js`
+
+Контент-скрипт добавляет интерактивную кнопку к любому элементу вида
+`div[class^="_paragraphOutputTab_"]` или `div[data-qa-type="paragraph-output-tabls"]`.
+При наведении курсора на такой блок появляется кнопка **"Забрать данные"**,
+которая извлекает содержимое расположенной в нём HTML-таблицы и сохраняет его в
+`chrome.storage.local` под ключом `parsedTableData`.
+

--- a/content.js
+++ b/content.js
@@ -1,0 +1,66 @@
+// Content script to show a button on Zeppelin output tables
+(function() {
+  // Create a single reusable button element
+  const hoverButton = document.createElement('button');
+  hoverButton.textContent = 'Забрать данные';
+  hoverButton.style.position = 'absolute';
+  hoverButton.style.top = '5px';
+  hoverButton.style.right = '5px';
+  hoverButton.style.zIndex = '9999';
+  hoverButton.style.background = '#569cd6';
+  hoverButton.style.color = '#fff';
+  hoverButton.style.border = 'none';
+  hoverButton.style.borderRadius = '4px';
+  hoverButton.style.padding = '4px 6px';
+  hoverButton.style.fontSize = '12px';
+  hoverButton.style.cursor = 'pointer';
+  hoverButton.style.display = 'none';
+
+  let currentContainer = null;
+
+  // Hide button helper
+  function hideButton() {
+    hoverButton.style.display = 'none';
+    if (currentContainer) {
+      currentContainer.removeEventListener('mouseleave', hideButton);
+      currentContainer = null;
+    }
+  }
+
+  // Parse table data inside container and store it
+  function extractTableData(container) {
+    const table = container.querySelector('table');
+    if (!table) {
+      console.log('Table Toolkit: no table found in container');
+      return;
+    }
+    const data = Array.from(table.rows).map(row =>
+      Array.from(row.cells).map(cell => cell.innerText)
+    );
+    chrome.storage.local.set({ parsedTableData: data }, () => {
+      console.log('Table Toolkit: table data saved', data);
+    });
+  }
+
+  hoverButton.addEventListener('click', () => {
+    if (currentContainer) {
+      extractTableData(currentContainer);
+    }
+  });
+
+  document.addEventListener('mouseover', (e) => {
+    const container = e.target.closest('div[data-qa-type="paragraph-output-tabls"], div[class^="_paragraphOutputTab_"]');
+    if (!container) return;
+
+    // Ensure container has positioning context
+    const computedStyle = window.getComputedStyle(container);
+    if (computedStyle.position === 'static') {
+      container.style.position = 'relative';
+    }
+
+    container.appendChild(hoverButton);
+    hoverButton.style.display = 'block';
+    currentContainer = container;
+    container.addEventListener('mouseleave', hideButton);
+  });
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,13 @@
   "background": {
     "service_worker": "background.js"
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_end"
+    }
+  ],
   "action": {
     "default_popup": "popup.html"
   },


### PR DESCRIPTION
## Summary
- add content script that shows a "Забрать данные" button when hovering a Zeppelin paragraph output div
- store table contents in `chrome.storage.local`
- register the new content script in the manifest
- document the content script in the README

## Testing
- `node -e "require('./content.js')"`
- `node -e "const fs=require('fs'); JSON.parse(fs.readFileSync('manifest.json','utf8')); console.log('ok');"`

------
https://chatgpt.com/codex/tasks/task_e_6861523fecd48331a24ed3e32ffb7e7a