### PR TITLE
Add custom header parsing

### DIFF
--- a/content.js
+++ b/content.js
@@ -2,20 +2,40 @@
   function extractTableData(depth = Infinity) {
     let limit = typeof depth === 'number' ? depth : Infinity;
     let data = [];
-    const table = document.querySelector('div[data-qa-type="paragraph-output-tabls"] table, div[class^="_paragraphOutputTab_"] table');
+
+    const containerSelector =
+      'div[data-qa-type="paragraph-output-tabls"], div[class^="_paragraphOutputTab_"], div[data-testid="output-content"]';
+
+    const table = document.querySelector(`${containerSelector} table`);
+
     if (table) {
       data = Array.from(table.rows)
         .slice(0, limit)
         .map(row => Array.from(row.cells).map(cell => cell.innerText.trim()));
     } else {
-      const rows = document.querySelectorAll('div[data-qa-type="paragraph-output-tabls"] [data-output-table="row"], div[class^="_paragraphOutputTab_"] [data-output-table="row"]');
+      const container = document.querySelector(containerSelector);
+      if (!container) return data;
+
+      const headerRow = container.querySelector('[data-output-table="table-header"]');
+      if (headerRow) {
+        const headerCells = headerRow.querySelectorAll('[data-output-table="cell"]');
+        const headers = Array.from(headerCells)
+          .slice(1)
+          .map(el => el.textContent.trim());
+        data.push(headers);
+      }
+
+      const rows = container.querySelectorAll('[data-output-table="row"]');
       rows.forEach((row, index) => {
         if (index >= limit) return;
         const cells = row.querySelectorAll('[data-output-table="cell"]');
-        const rowData = Array.from(cells).map(cell => cell.textContent.trim());
+        const rowData = Array.from(cells)
+          .slice(1)
+          .map(cell => cell.textContent.trim());
         data.push(rowData);
       });
     }
+
     return data;
   }
 


### PR DESCRIPTION
## Summary
- support headers inside containers with `data-output-table="table-header"`
- skip the index column when reading custom table rows

## Testing
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_6861778a7dc88331936d62193459baf1